### PR TITLE
Update T4/ResourceGenerator/ResourceGeneratorMetro.tt

### DIFF
--- a/T4/ResourceGenerator/ResourceGeneratorMetro.tt
+++ b/T4/ResourceGenerator/ResourceGeneratorMetro.tt
@@ -30,7 +30,7 @@ foreach(var resource in Resources.Named(new [] { "Sample" }, Path.GetDirectoryNa
         
 <#      foreach(var entry in resource.Entries) {#>
         /// <summary>
-        ///   Looks up a localized string similar to <#=entry.Value#>.
+        ///   Looks up a localized string similar to <#=entry.Value.Replace("\r", "").Replace("\n", "")#>.
         /// </summary>
         internal static string <#=entry.PropertyName#> { get { return ResourceLoader.GetString("<#=entry.KeyName#>"); } }
 <#      } #>


### PR DESCRIPTION
Fix that newlines in a resource text would also render a newline in the generated code, which would cause a compiler error
